### PR TITLE
Avoid overriding local changes when merging remote shelf

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,12 +137,13 @@ var shelf = {}
 
     shelf.remote_update = (a, f, b) => {
         if (b[1] > (a[1] ?? -1) || (b[1] == a[1] && greater_than(b[0], a[0]))) {
+            let local_change = Shelf.get_change(a, f)
             a[1] = b[1]
             if (is_obj(b[0])) {
                 a[0] = {}
                 shelf.merge(a, b)
             } else a[0] = b[0]
-            f = shelf.read(a)
+            if (!local_change) f = shelf.read(a)
         } else if (b[1] == a[1] && is_obj(a[0]) && is_obj(b[0])) {
             for (let [k, v] of Object.entries(b[0])) {
                 if (!a[0][k]) a[0][k] = [null, -1]


### PR DESCRIPTION
@dglittle 

First, thank you for this delightfully simple CRDT construction! I've been following your work and the Braid group for the last year and have adapted the Shelf for my current project. I particularly like its simplicity and malleability to introduce a change like the following.

I found that, when merging a `remote` shelf update while there are `local` pending changes, I want to preserve the local change in the frontend, so that it can still be 'committed' and 'rebased' on top of `remote`, which is akin to my preferred workflow with git as well. 

Have you found this is undesirable? Or are there other ways to handle similar cases with the existing API? 

(This PR is mostly for discussion only, I don't expect it getting merged!)