### PR TITLE
Wrap export in {}

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,4 +70,4 @@ function shelf_merge(shelf, incoming) {
     }
 }
 
-if (typeof module != 'undefined') module.exports = shelf_merge
+if (typeof module != 'undefined') module.exports = {shelf_merge}


### PR DESCRIPTION
README seems to assume the return value is an object, while the code exports only the function